### PR TITLE
Make API endpoints public and disable basic auth login prompt

### DIFF
--- a/src/main/java/com/group6/backend/SecurityConfig.java
+++ b/src/main/java/com/group6/backend/SecurityConfig.java
@@ -1,9 +1,13 @@
 package com.group6.backend;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
 
 @Configuration
 public class SecurityConfig {
@@ -12,11 +16,32 @@ public class SecurityConfig {
   SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
       .csrf(csrf -> csrf.disable())
+      .cors(cors -> cors.configurationSource(req -> {
+        CorsConfiguration c = new CorsConfiguration();
+        // add your frontend origins here as needed
+        c.setAllowedOrigins(List.of("*"));
+        c.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
+        c.setAllowedHeaders(List.of("*"));
+        c.setAllowCredentials(true);
+        return c;
+      }))
       .authorizeHttpRequests(auth -> auth
-        .requestMatchers("/api/health", "/api/test-db", "/api/db-time", "/api/words").permitAll()  // allow health without auth
-        .anyRequest().authenticated()                 // everything else protected (for later)
-      )
-      .httpBasic(basic -> {}); // keep simple Basic auth on protected routes for now
+        // public: landing + static + health/dev endpoints
+        .requestMatchers(
+          "/", "/index.html", "/error", "/favicon.ico",
+          "/static/**", "/assets/**", "/css/**", "/js/**",
+          "/actuator/**",
+          "/api/health", "/api/test-db", "/api/db-time",
+          "/api/words", "/api/words/**"
+        ).permitAll()
+        // preflight
+        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+        // everything else is also public for now (no login prompt)
+        .anyRequest().permitAll()
+      );
+      // ⚠️ No httpBasic() while we’re public; that’s what triggers the browser prompt
+
     return http.build();
   }
 }
+

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>Group 6 API</title></head>
+  <body>
+    <h1>Group 6 Backend</h1>
+    <p>Try: <code>/api/words</code> or <code>/api/words/daily</code></p>
+  </body>
+</html>


### PR DESCRIPTION
Fix the security issue that prompted a login when our Heroku app link was clicked.